### PR TITLE
Feature/auth

### DIFF
--- a/beerest/core/expect.py
+++ b/beerest/core/expect.py
@@ -45,6 +45,7 @@ class Expect:
             return self.equals(code)
         return self
         
+        
     def body(self, path: str = None) -> 'Expect':
         if path:
             if not self.response.json_data:
@@ -78,6 +79,14 @@ class Expect:
       if not passed:
           raise AssertionError(f"Expected {expected}, but got {self._current_value}")
       return self
+    
+    def is_not_empty(self) -> 'Expect':
+        return self._add_check(
+        bool(self._current_value),
+        "empty check",
+        self._current_value,
+        "non-empty value"
+    )
 
         
     def contains(self, expected: Any) -> 'Expect':
@@ -134,6 +143,14 @@ class Expect:
             "keys presence check",
             set(self._current_value.keys()),
             set(keys)
+        )
+    
+    def is_in(self, expected: Any) -> 'Expect':
+        return self._add_check(
+            self._current_value in expected,
+            "is in check",
+            self._current_value,
+            expected
         )
 
     def satisfies(self, predicate: Callable[[Any], bool], message: str = "custom check") -> 'Expect':

--- a/beerest/core/request.py
+++ b/beerest/core/request.py
@@ -1,7 +1,39 @@
-from typing import Dict, Any, Optional
-import httpx
+from typing import Dict, Any, Optional, Tuple
 from dataclasses import dataclass, field
-from .response import Response 
+from abc import ABC, abstractmethod
+import httpx
+from requests.auth import HTTPBasicAuth, HTTPDigestAuth
+from .response import Response
+
+class Authentication(ABC):
+    @abstractmethod
+    def apply(self, headers: Dict[str, str], auth: Optional[Any]) -> Tuple[Dict[str, str], Optional[Any]]:
+        """Apply authentication to the request"""
+        pass
+
+class BearerTokenAuth(Authentication):
+    def __init__(self, token: str):
+        self.token = token
+    
+    def apply(self, headers: Dict[str, str], auth: Optional[Any]) -> Tuple[Dict[str, str], Optional[Any]]:
+        headers['Authorization'] = f'Bearer {self.token}'
+        return headers, auth
+
+class BasicAuth(Authentication):
+    def __init__(self, username: str, password: str):
+        self.username = username
+        self.password = password
+    
+    def apply(self, headers: Dict[str, str], auth: Optional[Any]) -> Tuple[Dict[str, str], Optional[Any]]:
+        return headers, HTTPBasicAuth(self.username, self.password)
+
+class DigestAuth(Authentication):
+    def __init__(self, username: str, password: str):
+        self.username = username
+        self.password = password
+    
+    def apply(self, headers: Dict[str, str], auth: Optional[Any]) -> Tuple[Dict[str, str], Optional[Any]]:
+        return headers, HTTPDigestAuth(self.username, self.password)
 
 @dataclass
 class Request:
@@ -12,6 +44,7 @@ class Request:
     json_data: Optional[Dict[str, Any]] = None
     query_params: Dict[str, Any] = field(default_factory=dict)
     timeout: float = 5.0
+    authentication: Optional[Authentication] = None
 
     def to(self, endpoint: str) -> 'Request':
         self.url = f"{self.base_url}{endpoint}"
@@ -33,6 +66,22 @@ class Request:
         self.timeout = timeout
         return self
 
+    def with_basic_auth(self, username: str, password: str) -> 'Request':
+        self.authentication = BasicAuth(username, password)
+        return self
+
+    def with_digest_auth(self, username: str, password: str) -> 'Request':
+        self.authentication = DigestAuth(username, password)
+        return self
+
+    def with_bearer_token(self, token: str) -> 'Request':
+        self.authentication = BearerTokenAuth(token)
+        return self
+
+    def with_custom_auth(self, auth: Authentication) -> 'Request':
+        self.authentication = auth
+        return self
+
     def get(self) -> 'Response':
         return self._execute("GET")
 
@@ -50,14 +99,22 @@ class Request:
             raise ValueError("URL must start with 'http://' or 'https://'")
 
         self.method = method
+        headers = self.headers.copy()
+        auth = None
+
+        if self.authentication:
+            headers, auth = self.authentication.apply(headers, auth)
+
         with httpx.Client(timeout=httpx.Timeout(self.timeout)) as client:
             response = client.request(
                 method=method,
                 url=self.url,
-                headers=self.headers,
+                headers=headers,
                 json=self.json_data if method in ["POST", "PUT", "PATCH"] else None,
-                params=self.query_params
+                params=self.query_params,
+                auth=auth
             )
+
             json_data = None
             if response.headers.get('content-type', '').startswith('application/json'):
                 try:
@@ -70,5 +127,5 @@ class Request:
                 headers=dict(response.headers),
                 json_data=json_data,
                 text=response.text,
-                elapsed_time=response.elapsed.total_seconds() * 1000 
+                elapsed_time=response.elapsed.total_seconds() * 1000
             )

--- a/example/DummyJSON_example.py
+++ b/example/DummyJSON_example.py
@@ -1,0 +1,271 @@
+from beerest import Assertions, Expect, Test
+
+class TestDummyJSON(Test):
+    def setup_method(self):
+        super().setup_method()
+        self.request.base_url = "https://dummyjson.com"
+        
+    def test_get_all_products(self):
+        """Teste de GET para listar todos os produtos"""
+        response = self.request.to("/products").get()
+            
+        Expect(response) \
+            .status(200) \
+            .is_json() \
+            .body("total").greater_than(0) \
+            .body("limit").equals(30) \
+            .body("products").has_type("array")
+            
+    def test_get_single_product(self):
+        """Teste de GET para um produto específico"""
+        response = self.request.to("/products/1").get()
+        
+        Expect(response) \
+            .status(200) \
+            .body("id").equals(1) \
+            .body().has_keys("title", "price", "description", "category") \
+            .body("price").has_type("number")
+            
+    def test_search_products(self):
+        """Teste de busca de produtos"""
+        response = self.request \
+            .to("/products/search") \
+            .with_query({"q": "phone"}) \
+            .get()
+            
+        Expect(response) \
+            .status(200) \
+            .body("products") \
+            .satisfies(lambda products: all("phone" in product["title"].lower() for product in products))
+            
+    def test_add_product(self):
+        """Teste de POST para adicionar um novo produto"""
+        new_product = {
+            "title": "Test Smartphone",
+            "description": "A test smartphone",
+            "price": 549.99,
+            "category": "smartphones"
+        }
+        
+        response = self.request \
+            .to("/products/add") \
+            .with_headers({"Content-Type": "application/json"}) \
+            .with_body(new_product) \
+            .post()
+            
+        Expect(response) \
+            .status(201) \
+            .body("title").equals("Test Smartphone") \
+            .body("price").equals(549.99)
+            
+    def test_update_product(self):
+        """Teste de PUT para atualizar um produto"""
+        updated_data = {
+            "title": "Updated iPhone",
+            "price": 1099.99
+        }
+        
+        response = self.request \
+            .to("/products/1") \
+            .with_headers({"Content-Type": "application/json"}) \
+            .with_body(updated_data) \
+            .put()
+            
+        Expect(response) \
+            .status(200) \
+            .body("title").equals("Updated iPhone") \
+            .body("price").equals(1099.99)
+            
+    def test_delete_product(self):
+        """Teste de DELETE de um produto"""
+        response = self.request.to("/products/1").delete()
+            
+        Expect(response) \
+            .status(200) \
+            .body("isDeleted").equals(True) \
+            .body("deletedOn").is_not_empty()
+            
+    def test_product_schema(self):
+        """Teste de validação do schema de produto"""
+        product_schema = {
+            "type": "object",
+            "required": ["id", "title", "description", "price", "category"],
+            "properties": {
+                "id": {"type": "integer"},
+                "title": {"type": "string"},
+                "description": {"type": "string"},
+                "price": {"type": "number"},
+                "discountPercentage": {"type": "number"},
+                "rating": {"type": "number"},
+                "stock": {"type": "integer"},
+                "brand": {"type": "string"},
+                "category": {"type": "string"},
+                "thumbnail": {"type": "string"},
+                "images": {
+                    "type": "array",
+                    "items": {"type": "string"}
+                }
+            }
+        }
+        
+        response = self.request.to("/products/1").get()
+        
+        Expect(response) \
+            .status(200) \
+            .body() \
+            .matches_schema(product_schema)
+
+    def test_get_product_categories(self):
+        """Teste para listar todas as categorias de produtos"""
+        response = self.request.to("/products/categories").get()
+        
+        Expect(response) \
+            .status(200) \
+            .body().has_type("array") \
+            .body().is_not_empty()
+            
+    def test_get_products_by_category(self):
+        """Teste para buscar produtos por categoria"""
+        response = self.request.to("/products/category/smartphones").get()
+        
+        Expect(response) \
+            .status(200) \
+            .body("products") \
+            .satisfies(lambda products: all(product["category"] == "smartphones" for product in products))
+        
+    def test_login_success(self):
+        """Teste de login com sucesso e obtenção de token"""
+        user = {
+          "username":"emilys",
+          "password":"emilyspass"
+        }
+          
+        response = self.request \
+            .to("/auth/login") \
+            .with_headers({"Content-Type": "application/json"}) \
+            .with_body(user)\
+            .post()
+            
+        Expect(response) \
+            .status(200) \
+            .body().has_keys("id", "username", "email", "firstName", "lastName", "token") \
+            .body("token").is_not_empty() \
+            .body("username").equals(user["username"])
+            
+    def test_login_invalid_credentials(self):
+        """Teste de login com credenciais inválidas"""
+        invalid_user = {
+            "username": "invalid_user",
+            "password": "wrong_password"
+        }
+        
+        response = self.request \
+            .to("/auth/login") \
+            .with_headers({"Content-Type": "application/json"}) \
+            .with_body(invalid_user) \
+            .post()
+            
+        Expect(response) \
+            .status(400) \
+            .body("message").equals("Invalid credentials")
+
+    def test_get_auth_user(self):
+        """Teste para obter informações do usuário autenticado"""
+        # Primeiro fazemos login para obter o token
+
+        user = {
+          "username":"emilys",
+          "password":"emilyspass"
+        }
+
+        login_response = self.request \
+            .to("/auth/login") \
+            .with_headers({"Content-Type": "application/json"}) \
+            .with_body(user) \
+            .post()
+        
+        token = login_response.json_data["accessToken"]
+        
+        # Agora fazemos a requisição autenticada
+        response = self.request \
+            .to("/auth/me") \
+            .with_bearer_token(token) \
+            .get()
+            
+        Expect(response) \
+            .status(200) \
+            .body("username").equals(user["username"]) \
+            .body().has_keys("id", "username", "email", "firstName", "lastName")
+            
+    def test_get_auth_user_invalid_token(self):
+        """Teste para obter informações do usuário com token inválido"""
+        response = self.request \
+            .to("/auth/me") \
+            .with_bearer_token("invalid_token") \
+            .get()
+            
+        Expect(response) \
+            .status(401) \
+            .body("message").equals("Invalid/Expired Token!")
+            
+    def test_auth_user_schema(self):
+        """Teste de validação do schema do usuário autenticado"""
+
+        user = {
+          "username":"emilys",
+          "password":"emilyspass"
+        }
+
+        user_schema = {
+            "type": "object",
+            "required": ["id", "username", "email", "firstName", "lastName"],
+            "properties": {
+                "id": {"type": "integer"},
+                "username": {"type": "string"},
+                "email": {"type": "string"},
+                "firstName": {"type": "string"},
+                "lastName": {"type": "string"},
+                "gender": {"type": "string"},
+                "image": {"type": "string"},
+                "token": {"type": "string"}
+            }
+        }
+        
+        # Fazemos login primeiro
+        login_response = self.request \
+            .to("/auth/login") \
+            .with_headers({"Content-Type": "application/json"}) \
+            .with_body(user) \
+            .post()
+            
+        token = login_response.json_data["accessToken"]
+        
+        # Validamos o schema da resposta do usuário autenticado
+        response = self.request \
+            .to("/auth/me") \
+            .with_bearer_token(token) \
+            .get()
+            
+        Expect(response) \
+            .status(200) \
+            .body() \
+            .matches_schema(user_schema)
+
+    def test_login_with_expiresInMins(self):
+        """Teste de login especificando tempo de expiração do token"""
+        login_data = {
+            "username":"emilys",
+            "password":"emilyspass",
+            "expiresInMins": 60  # Token expira em 1 hora
+        }
+        
+        response = self.request \
+            .to("/auth/login") \
+            .with_headers({"Content-Type": "application/json"}) \
+            .with_body(login_data) \
+            .post()
+            
+        Expect(response) \
+            .status(200) \
+            .body("token").is_not_empty() \
+            .body("username").equals(login_data["username"])

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
   name="beerest",
-  version="0.2.0",
+  version="0.3.0",
   packages=find_packages(),
   install_requires=[
         'httpx',


### PR DESCRIPTION
# Add Authentication Support

Adds authentication support (Bearer Token, Basic Auth, Digest Auth) to Request class.

## Changes
- Added Authentication base class
- Added auth implementations (Bearer, Basic, Digest)
- Added auth methods to Request class
- Updated Request._execute() to handle auth

## Example
```python
# Bearer Token
request = Request("https://api.example.com").with_bearer_token("token").get()

# Basic Auth
request = Request("https://api.example.com").with_basic_auth("user", "pass").get()
```